### PR TITLE
for testing purposes, we have commented out the line that sets `SECUR…

### DIFF
--- a/backend/community/settings.py
+++ b/backend/community/settings.py
@@ -191,7 +191,7 @@ if DEBUG == False:
     STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
 
     # Security settings
-    SECURE_SSL_REDIRECT = True
+    # SECURE_SSL_REDIRECT = True
     SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
     SECURE_HSTS_SECONDS = 31536000
     SECURE_HSTS_INCLUDE_SUBDOMAINS = True


### PR DESCRIPTION
…E_SSL_REDIRECT` to `True`. This change is intended to temporarily disable the SSL redirect for testing purposes.